### PR TITLE
Turn on framecapture by default for thumbnail and set max frame to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ The workflow configuration is set at deployment and is defined as environment va
 * **MediaConvert_Template_720p:**	The name of the SD template in MediaConvert
 * **Source:**	The name of the source S3 bucket
 * **WorkflowName:**	Used to tag all of the MediaConvert encoding jobs
-* **acceleratedTranscoding** Enabled Accelerated Transocding in MediaConvert. options include ENABLE, DISABLE, PREFERRED. for more detials please see: 
+* **acceleratedTranscoding** Enabled Accelerated Transocding in MediaConvert. options include ENABLE, DISABLE, PREFERRED. for more detials please see:
 * **enableSns** Send SNS notifications for the workflow results.
 * **enableSqs** Send the workflow results to an SQS queue
+* ***PreserveFilePathInOutput*** preserves the input file's path in the output folder
 
 ### WorkFlow Triggers
 
@@ -134,7 +135,7 @@ AWS MediaConvert Quality-defined Variable Bit-Rate (QVBR) control mode gets the 
 
 For more detail please see [QVBR and MediaConvert](https://docs.aws.amazon.com/mediaconvert/latest/ug/cbr-vbr-qvbr.html).
 
-## Accelerated Transcoding 
+## Accelerated Transcoding
 Version 5.1.0 introduces support for accelerated transcoding which is a pro tier  feature of AWS Elemental MediaConvert. This feature can be configured when launching the template with one of the following options:
 
 * **ENABLED** All files upload will have acceleration enabled. Files that are not supported will not be processed and the workflow will fail
@@ -186,7 +187,7 @@ aws s3 mb s3://my-bucket-us-east-1
 ```
 
 ### 3. Build MediaInfo
-Build MediaInfo using the following commands on an [EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html) running an Amazon Linux AMI. 
+Build MediaInfo using the following commands on an [EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html) running an Amazon Linux AMI.
 
 ```console
 sudo yum update -y
@@ -205,12 +206,12 @@ cd MediaInfo/Project/GNU/CLI/
 ```
 Copy the mediainfo binary into the `source/mediainfo/bin` directory of your cloned respository.
 
-If you'd like to use a precompiled MediaInfo binary for Lambda built by the MediaArea team, you can download it [here](https://mediaarea.net/en/MediaInfo/Download/Lambda). 
+If you'd like to use a precompiled MediaInfo binary for Lambda built by the MediaArea team, you can download it [here](https://mediaarea.net/en/MediaInfo/Download/Lambda).
 For more information, check out the [MediaInfo site](https://mediaarea.net/en/MediaInfo).
 
 
 ### 4. Create the deployment packages
-First change directory into the deployment directory. 
+First change directory into the deployment directory.
 Run the following commands to build the distribution.
 ```
 chmod +x ./build-s3-dist.sh
@@ -219,7 +220,7 @@ chmod +x ./build-s3-dist.sh
 
 > **Notes**: The _build-s3-dist_ script expects the bucket name as one of its parameters, and this value should not include the region suffix.
 
-Run this command to ensure that you are an owner of the AWS S3 bucket you are uploading files to. 
+Run this command to ensure that you are an owner of the AWS S3 bucket you are uploading files to.
 ```
 aws s3api head-bucket --bucket my-bucket-us-east-1 --expected-bucket-owner <YOUR-AWS-ACCOUNT-ID>
 ```

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -27,7 +27,7 @@ Parameters:
   FrameCapture:
     Description: If enabled, frame capture is added to the job submitted to MediaConvert
     Type: String
-    Default: No
+    Default: Yes
     AllowedValues:
       - Yes
       - No

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -73,6 +73,14 @@ Parameters:
       - Yes
       - No
 
+  InputS3Bucket:
+    Description: Name of the video input S3 bucket
+    Type: String
+
+  OutputS3Bucket:
+    Description: Name of the video output S3 bucket
+    Type: String
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -86,6 +94,8 @@ Metadata:
           - EnableSns
           - EnableSqs
           - PreserveFilePathInOutput
+          - InputS3Bucket
+          - OutputS3Bucket
       -
         Label:
           default: "AWS Elemental MediaConvert"
@@ -116,6 +126,10 @@ Metadata:
         default: Enable SQS Messaging
       PreserveFilePathInOutput:
         default: Preserve file path on output
+      InputS3Bucket:
+        default: Name of the video input S3 bucket
+      OutputS3Bucket:
+        default: Name of the video output S3 bucket
 
 Mappings:
   SourceCode:
@@ -412,6 +426,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     Properties:
+      BucketName: !Ref InputS3Bucket
       LoggingConfiguration:
         DestinationBucketName: !Ref Logs
         LogFilePrefix: s3-access/
@@ -453,6 +468,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     Properties:
+      BucketName: !Ref OutputS3Bucket
       LoggingConfiguration:
         DestinationBucketName: !Ref Logs
         LogFilePrefix: s3-access/

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -46,15 +46,15 @@ Parameters:
     Default: Yes
     AllowedValues:
       - Yes
-      - No    
-  
+      - No
+
   EnableSqs:
     Description: Publish the workflow results to an SQS queue to ingest upstream
     Type: String
     Default: Yes
     AllowedValues:
       - Yes
-      - No  
+      - No
 
   AcceleratedTranscoding:
     Description: Enable accelerated transcoding in AWS Elemental MediaConvert. PREFERRED will only use acceleration if the input files are supported. ENABLED acceleration is applied to all files (this will fail for unsupported file types) see MediaConvert Documentation for more detail https://docs.aws.amazon.com/mediaconvert/latest/ug/accelerated-transcoding.html
@@ -64,6 +64,14 @@ Parameters:
       - ENABLED
       - DISABLED
       - PREFERRED
+
+  PreserveFilePathInOutput:
+    Description: If true, preserves the input file's path in the output folder. For example, input file in s3://inputBucket/path1/path2/file1.mp4 will generate output s3://outputBucket/path1/path2/file1/mp4/file1.mp4 and s3://outputBucket/path1/path2/file1/mp4/hls
+    Type: String
+    Default: Yes
+    AllowedValues:
+      - Yes
+      - No
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -77,6 +85,7 @@ Metadata:
           - Glacier
           - EnableSns
           - EnableSqs
+          - PreserveFilePathInOutput
       -
         Label:
           default: "AWS Elemental MediaConvert"
@@ -105,6 +114,8 @@ Metadata:
         default: Enable SNS Notifications
       EnableSqs:
         default: Enable SQS Messaging
+      PreserveFilePathInOutput:
+        default: Preserve file path on output
 
 Mappings:
   SourceCode:
@@ -366,7 +377,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       BillingMode: PAY_PER_REQUEST
-      PointInTimeRecoverySpecification: 
+      PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: guid
@@ -618,7 +629,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   StepFunctionsRole:
     Type: AWS::IAM::Role
@@ -687,7 +698,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   InputValidateRole:
     Type: AWS::IAM::Role
@@ -744,6 +755,7 @@ Resources:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
           ErrorHandler: !GetAtt ErrorHandler.Arn
+
           WorkflowName: !Ref AWS::StackName
           Source: !Ref Source
           Destination: !Ref Destination
@@ -769,6 +781,7 @@ Resources:
           InputRotate: DEGREE_0
           EnableSns: !Ref EnableSns
           EnableSqs: !Ref EnableSqs
+          PreserveFilePathInOutput: !Ref PreserveFilePathInOutput
           AcceleratedTranscoding: !Ref AcceleratedTranscoding
           SOLUTION_IDENTIFIER: "AwsSolution/SO0021/%%VERSION%%"
     Metadata:
@@ -777,7 +790,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   MediainfoRole:
     Type: AWS::IAM::Role
@@ -841,7 +854,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   DynamoUpdateRole:
     Type: AWS::IAM::Role
@@ -906,7 +919,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   ProfilerRole:
     Type: AWS::IAM::Role
@@ -971,7 +984,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   EncodeRole:
     Type: AWS::IAM::Role
@@ -1043,7 +1056,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   OutputValidateRole:
     Type: AWS::IAM::Role
@@ -1114,7 +1127,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   ArchiveSourceRole:
     Type: AWS::IAM::Role
@@ -1178,7 +1191,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   SqsSendMessageRole:
     Type: AWS::IAM::Role
@@ -1251,7 +1264,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   SnsNotificationRole:
     Type: AWS::IAM::Role
@@ -1282,7 +1295,7 @@ Resources:
                   - !Ref SnsTopic
                 Condition:
                   Bool:
-                    'aws:SecureTransport': 'true'                
+                    'aws:SecureTransport': 'true'
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
@@ -1320,7 +1333,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   MediaPackageAssetsRole:
     Type: AWS::IAM::Role
@@ -1391,7 +1404,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   ErrorHandlerRole:
     Type: AWS::IAM::Role
@@ -1459,7 +1472,7 @@ Resources:
           - id: W89
             reason: "Lambda functions do not need a VPC"
           - id: W92
-            reason: "Lambda do not need ReservedConcurrentExecutions in this case"    
+            reason: "Lambda do not need ReservedConcurrentExecutions in this case"
 
   IngestWorkflow:
     Type: AWS::StepFunctions::StateMachine
@@ -1800,7 +1813,7 @@ Outputs:
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", SqsQueue]]
 
-  SqsARN: 
+  SqsARN:
     Description: AmazonSQS Queue ARN
-    Value: 
+    Value:
       !Sub ${SqsQueue.Arn}

--- a/source/custom-resource/lib/mediaconvert/templates/1080p_avc_aac_16x9_qvbr_no_preset.json
+++ b/source/custom-resource/lib/mediaconvert/templates/1080p_avc_aac_16x9_qvbr_no_preset.json
@@ -574,6 +574,46 @@
                         "StreamInfResolution": "INCLUDE"
                     }
                 }
+            },
+            {
+                "CustomName": "File Group",
+                "Name": "File Group",
+                "Outputs": [
+                    {
+                        "ContainerSettings": {
+                            "Container": "MP4",
+                            "Mp4Settings": {}
+                        },
+                        "VideoDescription": {
+                            "CodecSettings": {
+                                "Codec": "H_264",
+                                "H264Settings": {
+                                    "MaxBitrate": 5000000,
+                                    "Bitrate": 4500000,
+                                    "RateControlMode": "VBR"
+                                }
+                            }
+                        },
+                        "AudioDescriptions": [
+                            {
+                                "CodecSettings": {
+                                    "Codec": "AAC",
+                                    "AacSettings": {
+                                        "Bitrate": 96000,
+                                        "CodingMode": "CODING_MODE_2_0",
+                                        "SampleRate": 48000
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "OutputGroupSettings": {
+                    "Type": "FILE_GROUP_SETTINGS",
+                    "FileGroupSettings": {
+                        "Destination": "s3://bucket/out"
+                    }
+                }
             }
         ],
         "AdAvailOffset": 0

--- a/source/custom-resource/lib/mediaconvert/templates/2160p_avc_aac_16x9_qvbr_no_preset.json
+++ b/source/custom-resource/lib/mediaconvert/templates/2160p_avc_aac_16x9_qvbr_no_preset.json
@@ -574,6 +574,46 @@
                         "StreamInfResolution": "INCLUDE"
                     }
                 }
+            },
+            {
+                "CustomName": "File Group",
+                "Name": "File Group",
+                "Outputs": [
+                    {
+                        "ContainerSettings": {
+                            "Container": "MP4",
+                            "Mp4Settings": {}
+                        },
+                        "VideoDescription": {
+                            "CodecSettings": {
+                                "Codec": "H_264",
+                                "H264Settings": {
+                                    "MaxBitrate": 5000000,
+                                    "Bitrate": 4500000,
+                                    "RateControlMode": "VBR"
+                                }
+                            }
+                        },
+                        "AudioDescriptions": [
+                            {
+                                "CodecSettings": {
+                                    "Codec": "AAC",
+                                    "AacSettings": {
+                                        "Bitrate": 96000,
+                                        "CodingMode": "CODING_MODE_2_0",
+                                        "SampleRate": 48000
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "OutputGroupSettings": {
+                    "Type": "FILE_GROUP_SETTINGS",
+                    "FileGroupSettings": {
+                        "Destination": "s3://bucket/out"
+                    }
+                }
             }
         ],
         "AdAvailOffset": 0

--- a/source/custom-resource/lib/mediaconvert/templates/720p_avc_aac_16x9_qvbr_no_preset.json
+++ b/source/custom-resource/lib/mediaconvert/templates/720p_avc_aac_16x9_qvbr_no_preset.json
@@ -465,6 +465,46 @@
                         "StreamInfResolution": "INCLUDE"
                     }
                 }
+            },
+            {
+                "CustomName": "File Group",
+                "Name": "File Group",
+                "Outputs": [
+                    {
+                        "ContainerSettings": {
+                            "Container": "MP4",
+                            "Mp4Settings": {}
+                        },
+                        "VideoDescription": {
+                            "CodecSettings": {
+                                "Codec": "H_264",
+                                "H264Settings": {
+                                    "MaxBitrate": 5000000,
+                                    "Bitrate": 4500000,
+                                    "RateControlMode": "VBR"
+                                }
+                            }
+                        },
+                        "AudioDescriptions": [
+                            {
+                                "CodecSettings": {
+                                    "Codec": "AAC",
+                                    "AacSettings": {
+                                        "Bitrate": 96000,
+                                        "CodingMode": "CODING_MODE_2_0",
+                                        "SampleRate": 48000
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "OutputGroupSettings": {
+                    "Type": "FILE_GROUP_SETTINGS",
+                    "FileGroupSettings": {
+                        "Destination": "s3://bucket/out"
+                    }
+                }
             }
         ],
         "AdAvailOffset": 0

--- a/source/encode/index.js
+++ b/source/encode/index.js
@@ -130,7 +130,8 @@ exports.handler = async (event) => {
 
     try {
         const inputPath = `s3://${event.srcBucket}/${event.srcVideo}`;
-        const outputPath = `s3://${event.destBucket}/${event.guid}`;
+        const subFolder = event.preserveFilePathInOutput ? event.destPathPreserved : event.guid;
+        const outputPath = `s3://${event.destBucket}/${subFolder}`
 
         // Baseline for the job parameters
         let job = {

--- a/source/encode/index.js
+++ b/source/encode/index.js
@@ -15,6 +15,11 @@ const AWS = require('aws-sdk');
 const error = require('./lib/error.js');
 const _ = require('lodash');
 
+// if we intend to only generate thumbnail, capture only one frame (first frame)
+const GENERATE_THUMBNAIL_ONLY = true
+const MAX_FRAME_CAPTURE = GENERATE_THUMBNAIL_ONLY ? 1 : 10000000
+
+
 const getMp4Group = (outputPath) => ({
     Name: 'File Group',
     OutputGroupSettings: {
@@ -104,7 +109,7 @@ const getFrameGroup = (event, outputPath) => ({
             AntiAlias: 'ENABLED',
             CodecSettings: {
                 FrameCaptureSettings: {
-                    MaxCaptures: 10000000,
+                    MaxCaptures: MAX_FRAME_CAPTURE,
                     Quality: 80,
                     FramerateDenominator: 5,
                     FramerateNumerator: 1

--- a/source/input-validate/index.js
+++ b/source/input-validate/index.js
@@ -41,7 +41,8 @@ exports.handler = async (event) => {
             inputRotate: process.env.InputRotate,
             acceleratedTranscoding: process.env.AcceleratedTranscoding,
             enableSns:JSON.parse(process.env.EnableSns),
-            enableSqs:JSON.parse(process.env.EnableSqs)
+            enableSqs:JSON.parse(process.env.EnableSqs),
+            preserveFilePathInOutput: JSON.parse(process.env.PreserveFilePathInOutput)
         };
 
         switch (event.workflowTrigger) {

--- a/source/input-validate/lib/index.spec.js
+++ b/source/input-validate/lib/index.spec.js
@@ -28,6 +28,7 @@ describe('#INPUT VALIDATE::', () => {
     process.env.AcceleratedTranscoding = 'DISABLED'
     process.env.EnableSns = 'true';
     process.env.EnableSqs = 'true';
+    process.env.PreserveFilePathInOutput = 'true';
 
     const _video = {
         workflowTrigger: 'Video',

--- a/source/profiler/index.js
+++ b/source/profiler/index.js
@@ -13,6 +13,7 @@
 
 const AWS = require('aws-sdk');
 const error = require('./lib/error.js');
+const Path = require('path');
 
 exports.handler = async (event) => {
     console.log(`REQUEST:: ${JSON.stringify(event, null, 2)}`);
@@ -38,6 +39,10 @@ exports.handler = async (event) => {
         });
 
         let mediaInfo = JSON.parse(event.srcMediainfo);
+        // in case we want to preserve the original file path
+        const {dir: srcDir, name: srcName} = Path.parse(mediaInfo.filename)
+        event.destPathPreserved = `${srcDir}/${srcName}`
+
         event.srcHeight = mediaInfo.video[0].height;
         event.srcWidth = mediaInfo.video[0].width;
 

--- a/source/profiler/lib/index.spec.js
+++ b/source/profiler/lib/index.spec.js
@@ -33,7 +33,7 @@ describe('#PROFILER::', () => {
     const data = {
         Item: {
             guid: '12345678',
-            srcMediainfo: '{ "video": [{ "height": 720, "width": 1280 }] }',
+            srcMediainfo: JSON.stringify({video: [{ "height": 720, "width": 1280 }], filename: 'video.mp4'}),
             jobTemplate_2160p: 'tmpl1',
             jobTemplate_1080p: 'tmpl2',
             jobTemplate_720p: 'tmpl3',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The following customization has been made to the solution: 

* The names of the input and output buckets are provided as CloudFormation parameters. Note that the bucket names must be DNS friendly and should not contain the “.” character.
* A new parameter PreserveFilePathInOutput has been added as a CloudFormation parameter, When this is set to true, the path of the input file will be preserved in the output. This is set to true by default.
* A new File Group has been added to the output templates to generate output in MP4 VBR format.
* Frame capture is turned on by default and the max frame is set to 1 so we can capture the first frame as the thumbnail.
